### PR TITLE
Fix exception getting objectlist from window with parentheses in its name

### DIFF
--- a/Ldtpd/Utils.cs
+++ b/Ldtpd/Utils.cs
@@ -141,7 +141,7 @@ namespace Ldtpd
             ArrayList objectList = new ArrayList();
             // Trying to mimic python fnmatch.translate
             String tmp = Regex.Replace(windowName, @"\*", @".*");
-            tmp = Regex.Replace(tmp, @"\?", @".");
+            tmp = Regex.Replace(tmp, @"[\+\[\]\(\)\?]+", @".+");
             tmp = Regex.Replace(tmp, @"\\", @"\\");
             tmp = Regex.Replace(tmp, "( |\r|\n)", "");
             tmp = @"\A(?ms)" + tmp + @"\Z(?ms)";


### PR DESCRIPTION
The windowname is used in a regular expression, so parens and other
regex special characters need to be escaped/replaced.

e.g. u'frmfavicon.ico (16\xd716) - Foo'
