### PR TITLE
Added build_installer.bat

### DIFF
--- a/CobraWinLDTP/CobraWinLDTP.wxs
+++ b/CobraWinLDTP/CobraWinLDTP.wxs
@@ -94,7 +94,7 @@ SOFTWARE.
             <File Id='CobraWinLDTPEXE'
                   Name='CobraWinLDTP.exe'
                   DiskId='1'
-                  Source='CobraWinLDTP.exe'
+                  Source='CobraWinLDTP\bin\Release\CobraWinLDTP.exe'
                   KeyPath='yes'>
             <!--
             <Shortcut Id="startmenuWinLDTPService"
@@ -119,7 +119,7 @@ SOFTWARE.
             <File Id='SetEnvironmentVariableexe'
                   Name='SetEnvironmentVariable.exe'
                   DiskId='1'
-                  Source='SetEnvironmentVariable.exe'
+                  Source='../SetEnvironmentVariable/bin/Release/SetEnvironmentVariable.exe'
                   KeyPath='yes' />
          </Component>
 
@@ -139,7 +139,7 @@ SOFTWARE.
             <File Id='LDTPDLL'
                   Name='Ldtp.dll'
                   DiskId='1'
-                  Source='Ldtp.dll'
+                  Source='../Ldtp/bin/Release/Ldtp.dll'
                   KeyPath='yes' />
          </Component>
 
@@ -159,7 +159,7 @@ SOFTWARE.
             <File Id='LdtpdDLL'
                   Name='Ldtpd.dll'
                   DiskId='1'
-                  Source='Ldtpd.dll'
+                  Source='../Ldtpd/bin/Release/Ldtpd.dll'
                   KeyPath='yes' />
          </Component>
 

--- a/build_installer.bat
+++ b/build_installer.bat
@@ -1,0 +1,20 @@
+@ECHO OFF
+
+REM Configure tool locations
+SET MSBUILD=C:\Program Files (x86)\MSBuild\12.0\Bin\MSBuild.exe
+SET WIX=C:\Program Files (x86)\WiX Toolset v3.9\bin
+
+REM ===========================================================
+
+"%MSBUILD%" -t:Build -p:Configuration=Release || GOTO END
+
+REM FIXME: JUST SINCE I DON'T NEED IT ATM
+COPY NUL CobraWinLDTP\ldtp\Ldtp.jar || GOTO END
+
+"%WIX%\candle.exe" -pedantic CobraWinLDTP\CobraWinLDTP.wxs -out CobraWinLDTP\CobraWinLDTP.wixobj || GOTO END
+"%WIX%\light.exe" -pedantic -spdb -dcl:high -ext WixUIExtension -ext WixUtilExtension -dWixUILicenseRtf=License.rtf -out CobraWinLDTP.msi CobraWinLDTP\CobraWinLDTP.wixobj || GOTO END
+EXIT /B 0
+
+:END
+echo "Command errored, aborting..."
+EXIT /B %ERRORLEVEL%


### PR DESCRIPTION
The script will build the solution using msbuild and then create
the msi installer using wix.

I have updated the Source locations in the .wxs file to avoid
having to copy files around which was confusing and easy to mess up.

Currently hardcoded to use the Release versions of the files and
using my tool locations by default.

But note: Does not handle/build the .jar file atm.