### PR TITLE
SetValue and GetValue fix

### DIFF
--- a/Ldtpd/Value.cs
+++ b/Ldtpd/Value.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Cobra WinLDTP 4.0
  * 
  * Author: Nagappan Alagappan <nalagappan@vmware.com>
@@ -76,15 +76,17 @@ namespace Ldtpd
                         "Object state is disabled");
                 }
                 childHandle.SetFocus();
-                if (childHandle.TryGetCurrentPattern(RangeValuePattern.Pattern,
+                if (childHandle.TryGetCurrentPattern(LegacyIAccessiblePattern.Pattern,
                     out pattern))
                 {
-                    if (((RangeValuePattern)pattern).Current.IsReadOnly)
+/*                    
+                    if (((LegacyIAccessiblePattern)pattern).Current.IsReadOnly)
                     {
                         throw new XmlRpcFaultException(123,
                             "Control is read-only.");
                     }
-                    ((RangeValuePattern)pattern).SetValue(value);
+*/
+                    ((LegacyIAccessiblePattern)pattern).SetValue(Convert.ToString(value, CultureInfo.InvariantCulture));
                     return 1;
                 }
             }
@@ -112,15 +114,17 @@ namespace Ldtpd
             try
             {
                 childHandle.SetFocus();
-                if (childHandle.TryGetCurrentPattern(RangeValuePattern.Pattern,
+                if (childHandle.TryGetCurrentPattern(LegacyIAccessiblePattern.Pattern,
                     out pattern))
                 {
-                    if (((RangeValuePattern)pattern).Current.IsReadOnly)
+/*                    
+                    if (((LegacyIAccessiblePattern)pattern).Current.IsReadOnly)
                     {
                         throw new XmlRpcFaultException(123,
                             "Control is read-only.");
                     }
-                    return ((RangeValuePattern)pattern).Current.Value;
+*/
+                    return Convert.ToDouble(((LegacyIAccessiblePattern)pattern).Current.Value, CultureInfo.InvariantCulture);
                 }
             }
             catch (Exception ex)

--- a/Ldtpd/Value.cs
+++ b/Ldtpd/Value.cs
@@ -307,7 +307,7 @@ namespace Ldtpd
         }
         public int Increase(string windowName, string objName, int iterations)
         {
-            double max = GetMaxValue(windowName, objName);
+            double max = Double.MaxValue;//GetMaxValue(windowName, objName);
             double value = GetValue(windowName, objName);
             bool flag = false;
             for (int i = 0; i < iterations; i++)
@@ -327,7 +327,7 @@ namespace Ldtpd
         }
         public int Decrease(string windowName, string objName, int iterations)
         {
-            double min = GetMinValue(windowName, objName);
+            double min = Double.MinValue;//GetMinValue(windowName, objName);
             double value = GetValue(windowName, objName);
             bool flag = false;
             for (int i = 0; i < iterations; i++)

--- a/build_installer.bat
+++ b/build_installer.bat
@@ -1,8 +1,8 @@
 @ECHO OFF
 
 REM Configure tool locations
-SET MSBUILD=C:\Program Files (x86)\MSBuild\12.0\Bin\MSBuild.exe
-SET WIX=C:\Program Files (x86)\WiX Toolset v3.9\bin
+SET MSBUILD=C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe
+SET WIX=C:\Program Files (x86)\WiX Toolset v3.10\bin
 
 REM ===========================================================
 


### PR DESCRIPTION
At least when using Qt sliders and spinboxes, the previous implementation using RangeValuePattern didn't work. I changed it to LegacyIAccessiblePattern, which fixed the problem. Using that I had to disable ReadOnly checks and min and max checks, because LegacyIAccessiblePattern doesn't provide them.

Note that I have only tested this with the Qt sliders and spinboxes. I don't know if the old implementation works in some other cases.

Also note that SetValue won't work with current out-of-the-box Qt's, because they haven't implemented the SetValue (QWindowsMsaaAccessible::put_accValue) in their end. I modified Qt also to make it work.