### PR TITLE
Add netsh urlacl rules on install and remove on uninstall.

### DIFF
--- a/CobraWinLDTP.Wix/CobraWinLDTP.wxs
+++ b/CobraWinLDTP.Wix/CobraWinLDTP.wxs
@@ -532,10 +532,77 @@ SOFTWARE.
                         Return="check">
         </CustomAction>
 
+        <CustomAction   Id="ListenerServiceAddLocalHostReservation"
+                        Execute='commit'
+                        Impersonate='no'
+                        Directory="INSTALLDIR"
+                        ExeCommand="netsh http add urlacl url=http://localhost:4118/ user=[%USERNAME]"
+                        Return="check" />
+
+        <CustomAction   Id="ListenerServiceAddLocalIPReservation"
+                        Execute='commit'
+                        Impersonate='no'
+                        Directory="INSTALLDIR"
+                        ExeCommand="netsh http add urlacl url=http://+:4118/ user=[%USERNAME]"
+                        Return="check" />
+
+        <CustomAction   Id="ListenerServiceAddAllIPReservation"
+                        Execute='commit'
+                        Impersonate='no'
+                        Directory="INSTALLDIR"
+                        ExeCommand="netsh http add urlacl url=http://*:4118/ user=[%USERNAME]"
+                        Return="check" />
+
+        <CustomAction   Id="ListenerServiceRemoveLocalHostReservation"
+                        Execute='commit'
+                        Impersonate='no'
+                        Directory="INSTALLDIR"
+                        ExeCommand="netsh http delete urlacl url=http://localhost:4118/"
+                        Return="check" />
+
+        <CustomAction   Id="ListenerServiceRemoveLocalIPReservation"
+                        Execute='commit'
+                        Impersonate='no'
+                        Directory="INSTALLDIR"
+                        ExeCommand="netsh http delete urlacl url=http://+:4118/"
+                        Return="check" />
+
+        <CustomAction   Id="ListenerServiceRemoveAllIPReservation"
+                        Execute='commit'
+                        Impersonate='no'
+                        Directory="INSTALLDIR"
+                        ExeCommand="netsh http delete urlacl url=http://*:4118/"
+                        Return="check" />                        
+                        
         <InstallExecuteSequence> 
             <WriteEnvironmentStrings />
+            <Custom Action="ListenerServiceAddLocalHostReservation"
+                    Before='InstallFinalize'>
+                    <![CDATA[(VersionNT >= 601)]]> AND (NOT Installed) AND (NOT REMOVE)
+                    </Custom>
+            <Custom Action="ListenerServiceAddLocalIPReservation"
+                    Before='InstallFinalize'>
+                    <![CDATA[(VersionNT >= 601)]]> AND (NOT Installed) AND (NOT REMOVE)
+                    </Custom>
+            <Custom Action="ListenerServiceAddAllIPReservation"
+                    Before='InstallFinalize'>
+                    <![CDATA[(VersionNT >= 601)]]> AND (NOT Installed) AND (NOT REMOVE)
+                    </Custom>
             <Custom Action="LaunchSetEnvironmentVariable" 
                     After="InstallFinalize">NOT Installed</Custom>
+            <!-- Remove URL reservation -->
+            <Custom Action="ListenerServiceRemoveLocalHostReservation"
+                    Before='InstallFinalize'>
+                    <![CDATA[(VersionNT >= 601)]]> AND (NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")
+                    </Custom>
+            <Custom Action="ListenerServiceRemoveLocalIPReservation"
+                    Before='InstallFinalize'>
+                    <![CDATA[(VersionNT >= 601)]]> AND (NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")
+                    </Custom>
+            <Custom Action="ListenerServiceRemoveAllIPReservation"
+                    Before='InstallFinalize'>
+                    <![CDATA[(VersionNT >= 601)]]> AND (NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")
+                    </Custom>
         </InstallExecuteSequence>
 
         <UI>


### PR DESCRIPTION
This PR is changing installer behaviour. Now urlacls added on installation and remove on uninstallation.

**Note, before testing installation using msi compiled from this commit**:
1. Make sure that previous installation successful uninstalled. This means, that no information in registry folder `HKEY_CURRENT_USER\Software\Microsoft\Installer\Products` for example:

![image](https://user-images.githubusercontent.com/6154870/67236770-9113cb80-f452-11e9-87c6-edcc98cf0c7f.png)

2. Make sure, that previous urlacls deleted (if not, delete it using administrator cmd):
```
netsh http delete urlacl url=http://*:4118/
netsh http delete urlacl url=http://+:4118/
netsh http delete urlacl url=http://localhost:4118/
```